### PR TITLE
Task/JO-107 Integrate 2.0.0 beta3 SDKs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ android/.idea
 android/.gradle
 android/local.properties
 android/*.iml
-      
+
+example/android/app/KeyStore/

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -13,14 +13,14 @@ apply plugin: 'com.android.library'
 apply from: 'jacoco.gradle'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
-        versionName "2.0.0-beta1"
+        versionName "2.0.0-beta2"
     }
     lintOptions {
         abortOnError false
@@ -40,7 +40,7 @@ repositories {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
 
-    implementation 'com.github.FidelLimited:android-sdk:2.0.0-beta2'
+    implementation 'com.github.FidelLimited:android-sdk:2.0.0-beta3'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'androidx.test.ext:junit:1.1.3'

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustResize">
+        android:windowSoftInputMode="adjustResize"
+          android:exported="true">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     ext {
         buildToolsVersion = "30.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 30
-        targetSdkVersion = 30
+        compileSdkVersion = 31
+        targetSdkVersion = 31
         ndkVersion = "21.4.7075529"
     }
     repositories {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
     - React-Core (= 0.66.1)
     - React-jsi (= 0.66.1)
     - ReactCommon/turbomodule/core (= 0.66.1)
-  - Fidel (2.0.0-beta2)
+  - Fidel (2.0.0-beta3)
   - fidel-react-native (2.0.0-beta1):
     - Fidel
     - React
@@ -488,7 +488,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Fidel:
-    :commit: 5486f807842c0dc4c9711e13bb2fa446ec7d99ff
+    :commit: 2c26c8612363efc80a686743af160b02b5787a39
     :git: https://github.com/FidelLimited/fidel-ios
 
 SPEC CHECKSUMS:
@@ -497,7 +497,7 @@ SPEC CHECKSUMS:
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: 500821d196c3d1bd10e7e828bc93ce075234080f
   FBReactNativeSpec: 74c869e2cffa2ffec685cd1bac6788c021da6005
-  Fidel: fc665ba7ebbdf3a04440f2a92cf8bfe64618b0b3
+  Fidel: 115a36a8eb2f5d0ef60e50876c5d47de1a767b8a
   fidel-react-native: e9a1e4f4fa283b6b53c257b39d8033b18005cc7b
   Flipper: 30e8eeeed6abdc98edaf32af0cda2f198be4b733
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c

--- a/example/ios/example.xcodeproj/xcshareddata/xcschemes/example.xcscheme
+++ b/example/ios/example.xcodeproj/xcshareddata/xcschemes/example.xcscheme
@@ -41,9 +41,9 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2801,10 +2801,9 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fidel-react-native@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/fidel-react-native/-/fidel-react-native-1.5.0.tgz#ea694bf93de4ba56b8079c8f8d95888316e97696"
-  integrity sha512-JWS7OPhemcq1zXo0kbZMeipQkXkoFbC2Cguk6FoP3mmEN0lwUTrbvk2sYirQGYnIoL0Ia6mdmxkNgRf+dg7zRQ==
+"fidel-react-native@https://github.com/FidelLimited/rn-sdk#em":
+  version "2.0.0-beta1"
+  resolved "https://github.com/FidelLimited/rn-sdk#009f87c832a1fccb27faff16e67daa2006f844d1"
 
 file-entry-cache@^5.0.1:
   version "5.0.1"

--- a/ios/JSProperties.swift
+++ b/ios/JSProperties.swift
@@ -10,7 +10,6 @@ import Foundation
 enum JSProperties: String {
     case sdkKey
     case programID = "programId"
-    case companyName
     case programType
     case options
     case consentText
@@ -26,6 +25,7 @@ enum JSProperties: String {
     enum ConsentText: String {
         case termsAndConditionsURL = "termsAndConditionsUrl"
         case privacyPolicyURL = "privacyPolicyUrl"
+        case companyName
         case programName
         case deleteInstructions
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fidel-react-native",
-  "version": "2.0.0-beta1",
+  "version": "2.0.0-beta2",
   "description": "Fidel's React Native bridge library for iOS and Android.",
   "main": "index.js",
   "nativePackage": true,


### PR DESCRIPTION
[JO-107](https://fidel.atlassian.net/browse/JO-107)

**Changelog**
Updated the RN bridge library to point to and use the 2.0.0-beta3 native SDKs (iOS & Android).

**How to test**
1. Install the local SDK (which is the subject under testing) in the `example` project by running the following comand `sh ./scripts/installLocalLibrary.sh`
2. Open the iOS & Android example projects and check if all the bugs/tasks included in the 2.0.0-beta3 native SDKs work fine in React Native as well.

The tickets included in native 2.0.0-beta3 are: [JO-44](https://fidel.atlassian.net/browse/JO-44), [JO-45](https://fidel.atlassian.net/browse/JO-45), [JO-46](https://fidel.atlassian.net/browse/JO-46), [JO-47](https://fidel.atlassian.net/browse/JO-47), [JO-55](https://fidel.atlassian.net/browse/JO-55), [JO-60](https://fidel.atlassian.net/browse/JO-60)
