### PR TITLE
Provide all LinkResult fields in JavaScript, when the metaData is null.

### DIFF
--- a/android/src/test/java/com/fidelreactlibrary/WritableMapDataConverterTests.java
+++ b/android/src/test/java/com/fidelreactlibrary/WritableMapDataConverterTests.java
@@ -54,6 +54,43 @@ public class WritableMapDataConverterTests {
     }
 
     @Test
+    public void test_WhenExpectedNonNullStringFieldContainsNullValueInLinkResult_ReturnMapWithNullValueForIt() {
+        LinkResult linkResult = new LinkResult(TEST_CARD_ID);
+        setFieldsFor(linkResult);
+        linkResult.accountId = null;
+        WritableMap receivedMap = sut.getConvertedDataFor(linkResult);
+        assertNull(receivedMap.getString("accountId"));
+    }
+
+    @Test
+    public void test_WhenExpectedNonNullBooleanFieldContainsNullValueInLinkResult_ReturnMapWithFalseValueForIt() {
+        LinkResult linkResult = new LinkResult(TEST_CARD_ID);
+        setFieldsFor(linkResult);
+        linkResult.live = null;
+        WritableMap receivedMap = sut.getConvertedDataFor(linkResult);
+        assertFalse(receivedMap.getBoolean("live"));
+    }
+
+    @Test
+    public void test_WhenExpectedLinkResultWithNullMetaData_ReturnMapWithNullMetaData() {
+        LinkResult linkResult = new LinkResult(TEST_CARD_ID);
+        setFieldsFor(linkResult);
+        linkResult.metaData = null;
+        WritableMap receivedMap = sut.getConvertedDataFor(linkResult);
+        assertNull(receivedMap.getMap("metaData"));
+    }
+
+    @Test
+    public void test_WhenConvertingLinkResultWithError_AndErrorCodeIsUnknown_SetNullErrorCodeField() {
+        LinkResult linkResult = new LinkResult(null, TEST_ERROR_MESSAGE, "2021-05-19T12:37:55.278Z");
+        Object objectToConvert = linkResult.getError();
+
+        WritableMap receivedMap = sut.getConvertedDataFor(objectToConvert);
+        assertNotNull(receivedMap);
+        assertNull(receivedMap.getString("code"));
+    }
+
+    @Test
     public void test_WhenConvertingValidLinkResult_IncludeAllObjectFields() throws IllegalAccessException {
         LinkResult linkResult = new LinkResult(TEST_CARD_ID);
         setFieldsFor(linkResult);
@@ -98,7 +135,7 @@ public class WritableMapDataConverterTests {
                 assertEquals(receivedString, field.get(objectToConvert));
             }
             else if (field.getType() == LinkResultErrorCode.class) {
-                String displayFieldName = field.getName() == "errorCode" ? "code" : field.getName();
+                String displayFieldName = field.getName().equals("errorCode") ? "code" : field.getName();
                 String receivedErrorCodeString = receivedMap.getString(displayFieldName);
                 LinkResultErrorCode expectedErrorCode = (LinkResultErrorCode) field.get(objectToConvert);
                 String expectedErrorCodeString = expectedErrorCode.toString().toLowerCase();

--- a/example/App.js
+++ b/example/App.js
@@ -64,7 +64,7 @@ const App: () => Node = () => {
       if (error) {
         console.debug(error);
       } else {
-        console.info(result);
+        console.debug(result);
       }
     });
   }

--- a/example/package.json
+++ b/example/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "fidel-react-native": "1.5.0",
+    "fidel-react-native": "1.6.0",
     "react": "17.0.2",
     "react-native": "0.66.1"
   },

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2801,10 +2801,10 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fidel-react-native@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/fidel-react-native/-/fidel-react-native-1.5.0.tgz#ea694bf93de4ba56b8079c8f8d95888316e97696"
-  integrity sha512-JWS7OPhemcq1zXo0kbZMeipQkXkoFbC2Cguk6FoP3mmEN0lwUTrbvk2sYirQGYnIoL0Ia6mdmxkNgRf+dg7zRQ==
+fidel-react-native@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/fidel-react-native/-/fidel-react-native-1.6.0.tgz#bfb5f9f2169d6f15e031dfe64f6d760a59304c90"
+  integrity sha512-tBTCKxTdCBv73o5EKGjpJOL95O8j4s6thCVtt6lmxYHxbo/mQqV1oBgBfjXMcdb9/FveS6gU+lVWgsxHTslGBw==
 
 file-entry-cache@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
Jira: [JO-124](https://fidel.atlassian.net/browse/JO-124)

**Changelog**
Provide/Map all result fields to be available in JavaScript, when running the Android RN project, even when the `metaData` field set by the developer is null.

**How to test**
1. Remove the `metaData` parameter given to the `Fidel.setOptions` function in the App.js file.
2. Set your SDK Key & Program ID in the App.js file.
3. Install the local SDK (which is the subject under testing) in the example project by running the following command: `sh ./scripts/installLocalLibrary.sh`.
4. Run the Android RN project and test that all fields listed in the screenshot below are displayed in the terminal (where you ran `npx react-native start` or `npm start`), after successfully linking a card.

<img width="229" alt="Screenshot 2022-03-07 at 15 24 33" src="https://user-images.githubusercontent.com/99485227/157052429-c2ddb3c9-5b54-496a-b83e-803314da3159.png">

