### PR TITLE
JO 114 Support latest npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ android/.idea
 android/.gradle
 android/local.properties
 android/*.iml
-      
+
+example/android/app/KeyStore/*

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,7 +39,7 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.github.FidelLimited:android-sdk:1.7.0'
+    implementation 'com.github.FidelLimited:android-sdk:1.7.1'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'androidx.test.ext:junit:1.1.2'

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
     - React-jsi (= 0.66.1)
     - ReactCommon/turbomodule/core (= 0.66.1)
   - Fidel (1.10.0)
-  - fidel-react-native (1.5.0):
+  - fidel-react-native (1.6.0):
     - Fidel
     - React
   - Flipper (0.99.0):
@@ -490,7 +490,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 500821d196c3d1bd10e7e828bc93ce075234080f
   FBReactNativeSpec: 74c869e2cffa2ffec685cd1bac6788c021da6005
   Fidel: d2dd53ab6eba7e550c9d71ae078f456ec09a2b4b
-  fidel-react-native: da51e51ea439df29fdbd9bf0f5e7ceebe0d4e1c5
+  fidel-react-native: ffc8cbdbcbcb5b565d5e8dc42deeeaa613eeeb88
   Flipper: 30e8eeeed6abdc98edaf32af0cda2f198be4b733
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 57ffbe81ef95306cc9e69c4aa3aeeeeb58a6a28c

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   },
   "homepage": "https://github.com/FidelLimited/rn-sdk#readme",
   "peerDependencies": {
-    "react-native": "^0.41.2"
+    "react": "*",
+    "react-native": "*"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
Jira: [JO-114](https://fidel.atlassian.net/browse/JO-114)

**Changelog**
Updated the Android SDK to version 1.7.1.
Updated the peer dependencies section in the package.json file to support installing the library using the latest npm version.

**How to test**
1. Modify the `scripts/installLocalLibrary.sh` at line 19:
`yarn add file:../$localLibraryPackage` -> (should become) `npm install file:../$localLibraryPackage` (this is to make sure that when installing the local RN library, we use `npm`, not yarn, as we want to test that installing our library with `npm` works fine).
2. Install our local library by running the `scripts/installLocalLibrary.sh` script:
`sh ./scripts/installLocalLibrary.sh`
3. Installing should work fine, without any errors.