### PR TITLE
Use native SDKs that support GBP card verification for UK issued cards.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,7 +39,7 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.github.FidelLimited:android-sdk:2.0.0-beta5'
+    implementation 'com.github.FidelLimited:android-sdk:2.0.0-beta7'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'androidx.test.ext:junit:1.1.3'

--- a/example/App.js
+++ b/example/App.js
@@ -38,12 +38,8 @@ export default class App extends React.Component {
     ];
 
     const countries = [
-      Fidel.Country.unitedArabEmirates,
       Fidel.Country.unitedKingdom,
       Fidel.Country.unitedStates,
-      Fidel.Country.japan,
-      Fidel.Country.sweden,
-      Fidel.Country.ireland,
       Fidel.Country.canada,
     ];
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
     - React-Core (= 0.66.1)
     - React-jsi (= 0.66.1)
     - ReactCommon/turbomodule/core (= 0.66.1)
-  - Fidel (2.0.0-beta5)
+  - Fidel (2.0.0-beta7)
   - fidel-react-native (2.0.0-beta4):
     - Fidel
     - React
@@ -488,7 +488,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Fidel:
-    :commit: 360758fc4e86b0c45daffc33df368b4c442244bd
+    :commit: d76d0389ffbf9c7f577e3c8fb7ac621809279d55
     :git: https://github.com/FidelLimited/fidel-ios
 
 SPEC CHECKSUMS:
@@ -497,7 +497,7 @@ SPEC CHECKSUMS:
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: 500821d196c3d1bd10e7e828bc93ce075234080f
   FBReactNativeSpec: 74c869e2cffa2ffec685cd1bac6788c021da6005
-  Fidel: eccdbc5eafdd623c0c84b89d9a4bd26327cf9b52
+  Fidel: 762e2a4e9da8cc7dc3efd54bc8cc2a5bc18f2ae9
   fidel-react-native: 3fce91d80ff616dce63e62995ab2c525589f2b51
   Flipper: 30e8eeeed6abdc98edaf32af0cda2f198be4b733
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
@@ -541,4 +541,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: d674182de9c4ad859c1d68a073b75d726c087230
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3


### PR DESCRIPTION
Jira: [IDK-116](https://fidelapi.atlassian.net/browse/IDK-116)

**Changelog**
Just pointing to the right private beta Android SDK version that supports GBP card verification
In the example project point to the latest private beta iOS SDK version that supports GBP card verification.
Limit the countries to US, Canada & UK, in the example project.

**Testing preparation**
1. Run the `scripts/installLocalLibrary.sh` script, from the root repo folder, to install the local RN bridge library in the example project
2. Add your SDK key and program ID in the `example/App.js` component.

**How to test on iOS**
1. Open the `example/ios/example.xcworkspace` file, if you have Xcode installed
2. Run the project on the simulator
3. Test with different scenarios

**How to test on Android**
1. Start the metro bundler, from the `example` folder: `npx react-native start`
2. Open the `example/android/` folder/project in Android Studio.
4. Run the project on the emulator of your choice.
5. If you receive an error saying `Unable to run script. Make sure you're running Metro [...]`, please run the following command: `adb reverse tcp:8081 tcp:8081`. Re-run the project on the emulator.
6. Test with different scenarios