### PR TITLE
Feature/IDK-237 Update private beta native Fidel SDKs

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,11 +1,12 @@
 
 buildscript {
     repositories {
+        google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:7.2.1'
     }
 }
 
@@ -13,12 +14,12 @@ apply plugin: 'com.android.library'
 apply from: 'jacoco.gradle'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 32
         versionCode 1
         versionName "2.0.0-beta4"
     }
@@ -39,7 +40,7 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.github.FidelLimited:android-sdk:2.0.0-beta7'
+    implementation 'com.github.FidelLimited:android-sdk:2.0.0-beta8'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'androidx.test.ext:junit:1.1.3'

--- a/android/src/main/java/com/fidelreactlibrary/adapters/ResultsAdapter.java
+++ b/android/src/main/java/com/fidelreactlibrary/adapters/ResultsAdapter.java
@@ -126,6 +126,8 @@ public final class ResultsAdapter implements DataAdapter<Object, WritableMap>, C
     private String getJSErrorType(FidelErrorType errorType) {
         if (errorType == FidelErrorType.UserCanceled.INSTANCE) {
             return "userCanceled";
+        } else if (errorType == FidelErrorType.DeviceNotSecure.INSTANCE) {
+            return "deviceNotSecure";
         } else if (errorType == FidelErrorType.SdkConfigurationError.INSTANCE) {
             return "sdkConfigurationError";
         } else if (errorType instanceof FidelErrorType.EnrollmentError) {
@@ -192,6 +194,7 @@ public final class ResultsAdapter implements DataAdapter<Object, WritableMap>, C
         Map<String, Object> errorConstants = new HashMap<>();
         Map<String, String> errorTypeConstants = new HashMap<>();
         putErrorTypeConstant(errorTypeConstants, FidelErrorType.UserCanceled.INSTANCE);
+        putErrorTypeConstant(errorTypeConstants, FidelErrorType.DeviceNotSecure.INSTANCE);
         putErrorTypeConstant(errorTypeConstants, FidelErrorType.SdkConfigurationError.INSTANCE);
         putErrorTypeConstant(errorTypeConstants, new FidelErrorType.EnrollmentError(EnrollmentErrorType.CARD_ALREADY_EXISTS));
         putErrorTypeConstant(errorTypeConstants, new FidelErrorType.VerificationError(VerificationErrorType.CARD_ALREADY_VERIFIED));

--- a/android/src/test/java/com/fidelreactlibrary/ResultsAdapterTests.java
+++ b/android/src/test/java/com/fidelreactlibrary/ResultsAdapterTests.java
@@ -41,11 +41,6 @@ public class ResultsAdapterTests {
     }
 
     @Test
-    public void test_WhenAskedTo() {
-        assertNull(sut.getAdaptedObjectFor(null));
-    }
-
-    @Test
     public void test_WhenAskedToConvertDeviceNotSecureObject_ShouldReturnCorrectErrorTypeForJS() {
         FidelError fidelError = new FidelError(FidelErrorType.DeviceNotSecure.INSTANCE, "some message", 123);
         assertEquals("deviceNotSecure", sut.getAdaptedObjectFor(fidelError).getString("type"));

--- a/android/src/test/java/com/fidelreactlibrary/ResultsAdapterTests.java
+++ b/android/src/test/java/com/fidelreactlibrary/ResultsAdapterTests.java
@@ -1,6 +1,8 @@
 package com.fidelreactlibrary;
 
 import com.facebook.react.bridge.JavaOnlyMap;
+import com.fidelapi.entities.FidelError;
+import com.fidelapi.entities.FidelErrorType;
 import com.fidelreactlibrary.adapters.ResultsAdapter;
 import com.fidelreactlibrary.fakes.CardSchemeAdapterStub;
 import com.fidelreactlibrary.fakes.CountryAdapterStub;
@@ -12,6 +14,8 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.*;
+
+import java.util.Map;
 
 //Custom test runner is necessary for being able to use JSONObject
 @RunWith(RobolectricTestRunner.class)
@@ -34,5 +38,42 @@ public class ResultsAdapterTests {
     @Test
     public void test_WhenAskedToConvertNullObject_ReturnNull() {
         assertNull(sut.getAdaptedObjectFor(null));
+    }
+
+    @Test
+    public void test_WhenAskedTo() {
+        assertNull(sut.getAdaptedObjectFor(null));
+    }
+
+    @Test
+    public void test_WhenAskedToConvertDeviceNotSecureObject_ShouldReturnCorrectErrorTypeForJS() {
+        FidelError fidelError = new FidelError(FidelErrorType.DeviceNotSecure.INSTANCE, "some message", 123);
+        assertEquals("deviceNotSecure", sut.getAdaptedObjectFor(fidelError).getString("type"));
+    }
+
+    @Test
+    public void test_WhenAskedToConvertDeviceNotSecureObject_ShouldReturnCorrectErrorMessageForJS() {
+        String testMessage = "some message";
+        FidelError fidelError = new FidelError(FidelErrorType.DeviceNotSecure.INSTANCE, testMessage, 123);
+        assertEquals(testMessage, sut.getAdaptedObjectFor(fidelError).getString("message"));
+    }
+
+    @Test
+    public void test_WhenAskedToConvertDeviceNotSecureObject_ShouldReturnCorrectDateForJS() {
+        long testDate = 123;
+        FidelError fidelError = new FidelError(FidelErrorType.DeviceNotSecure.INSTANCE, "some message", testDate);
+        assertEquals(testDate, sut.getAdaptedObjectFor(fidelError).getDouble("date"), 0.0001);
+    }
+
+    @Test
+    public void test_WhenAskedToGetAllConstantsToExport_ShouldIncludeDeviceNotSecureError() {
+        Map<String, Object> constants = sut.getConstants();
+        Object errorTypeConstants = constants.get("ErrorType");
+        if (!(errorTypeConstants instanceof Map)) {
+            fail("You should get a map of error types here");
+            return;
+        }
+        Map<String, String> errorTypeConstantsMap = (Map<String, String>)errorTypeConstants;
+        assertEquals("deviceNotSecure", errorTypeConstantsMap.get("deviceNotSecure"));
     }
 }

--- a/example/App.js
+++ b/example/App.js
@@ -90,6 +90,9 @@ export default class App extends React.Component {
       case Fidel.ErrorType.sdkConfigurationError:
         console.log("Please configure the Fidel SDK correctly");
         break;
+      case Fidel.ErrorType.deviceNotSecure:
+        console.log("Your card details are considered sensitive information. Make sure you're providing them only using secure devices.");
+        break;
       case Fidel.ErrorType.enrollmentError:
         this.handleEnrollmentError(error);
         break;

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     ext {
         buildToolsVersion = "30.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 31
-        targetSdkVersion = 31
+        compileSdkVersion = 32
+        targetSdkVersion = 32
         ndkVersion = "21.4.7075529"
     }
     repositories {
@@ -13,7 +13,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:7.0.3')
+        classpath('com.android.tools.build:gradle:7.2.1')
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
     - React-Core (= 0.66.1)
     - React-jsi (= 0.66.1)
     - ReactCommon/turbomodule/core (= 0.66.1)
-  - Fidel (2.0.0-beta7)
+  - Fidel (2.0.0-beta8)
   - fidel-react-native (2.0.0-beta4):
     - Fidel
     - React
@@ -488,7 +488,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Fidel:
-    :commit: d76d0389ffbf9c7f577e3c8fb7ac621809279d55
+    :commit: a92c5939fe47fb076c3c386da2255d492ca8a4da
     :git: https://github.com/FidelLimited/fidel-ios
 
 SPEC CHECKSUMS:
@@ -497,7 +497,7 @@ SPEC CHECKSUMS:
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: 500821d196c3d1bd10e7e828bc93ce075234080f
   FBReactNativeSpec: 74c869e2cffa2ffec685cd1bac6788c021da6005
-  Fidel: 762e2a4e9da8cc7dc3efd54bc8cc2a5bc18f2ae9
+  Fidel: ae4c6ec2c7783813ea5c482d9f629e7c18d7cdf3
   fidel-react-native: 3fce91d80ff616dce63e62995ab2c525589f2b51
   Flipper: 30e8eeeed6abdc98edaf32af0cda2f198be4b733
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2802,8 +2802,8 @@ fb-watchman@^2.0.0:
     bser "2.1.1"
 
 "fidel-react-native@https://github.com/FidelLimited/rn-sdk#em":
-  version "2.0.0-beta1"
-  resolved "https://github.com/FidelLimited/rn-sdk#009f87c832a1fccb27faff16e67daa2006f844d1"
+  version "2.0.0-beta4"
+  resolved "https://github.com/FidelLimited/rn-sdk#249741e0c572b46f9f464a89502ca52a2d9d341e"
 
 file-entry-cache@^5.0.1:
   version "5.0.1"

--- a/ios/Adapters/ErrorResultAdapter.swift
+++ b/ios/Adapters/ErrorResultAdapter.swift
@@ -29,6 +29,7 @@ extension FidelErrorType {
         case .verificationError: return "verificationError"
         case .userCanceled: return "userCanceled"
         case .sdkConfigurationError: return "sdkConfigurationError"
+        case .deviceNotSecure: return "deviceNotSecure"
         @unknown default: return "unknown"
         }
     }

--- a/ios/Constants/ErrorTypeConstants.swift
+++ b/ios/Constants/ErrorTypeConstants.swift
@@ -19,6 +19,7 @@ extension FidelErrorType: ConstantsProvider {
         case .verificationError: return "verificationError"
         case .sdkConfigurationError: return "sdkConfigurationError"
         case .userCanceled: return "userCanceled"
+        case .deviceNotSecure: return "deviceNotSecure"
         @unknown default: return "unexpected"
         }
     }


### PR DESCRIPTION
Jira: [IDK-237](https://fidelapi.atlassian.net/browse/IDK-237)

**Changelog:**
1. Update android gradle plugin version.
2. Prevent users from copying card details to the pasteboard from the card enrollment screen.
3. Allow editing the expiration date without switching to the country selector automatically.
4. When attempting to open the SDK and a rooted device is detected, the SDK does not open and it returns a specific error instead.

**How to test:**
Card details copying/sharing prevention test:
1. Write some card details in the card number, expiration month, expiration year input fields.
2. When tapping on those fields to copy, select, share the contents, those options should not be available.
5. Only the "Paste" menu option should be available, as the attached photo indicates.

Rooted device detection test:
1. Open the SDK on a rooted/jailbroken device.

![Screenshot_1658407451](https://user-images.githubusercontent.com/99485227/180216238-10fba800-0446-472e-b98d-74fcd4867403.png)