### PR TITLE
Podspec point same native version as package

### DIFF
--- a/fidel-react-native.podspec
+++ b/fidel-react-native.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m,swift}"
 
   s.dependency 'React'
-  s.dependency 'Fidel'
+  s.dependency 'Fidel', "#{s.version}"
 end


### PR DESCRIPTION
Since they are in sync it makes having like so makes it easier to upgrade. Otherwise by default a v1.x.x version is installed and requires adding the intended version to podspec

Tested this locally and right version is installed.